### PR TITLE
feat(redfish): replace legacy authorize flow with Redfish api for KVM/SOL

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -9,7 +9,7 @@ import {
   Sol,
   AttachDiskImage
 } from '@device-management-toolkit/ui-toolkit-react'
-import { useAuth } from './useAuth'
+import { useAuth, type ApiMode } from './useAuth'
 
 type TabType = 'kvm' | 'sol' | 'ider'
 
@@ -21,6 +21,7 @@ const TABS: { id: TabType; label: string }[] = [
 
 const App: React.FC = () => {
   const [activeTab, setActiveTab] = useState<TabType>('kvm')
+  const [apiMode, setApiMode] = useState<ApiMode>('legacy')
   const [config, setConfig] = useState({
     mpsServer: '',
     deviceId: '',
@@ -30,20 +31,32 @@ const App: React.FC = () => {
   })
 
   const auth = useAuth()
-  const getRelayServer = (baseUrl: string): string => {
-    if (baseUrl.startsWith('https://') || baseUrl.startsWith('http://')) {
-      return `${baseUrl}/relay`
+  const getRelayServer = (baseUrl: string, mode: ApiMode): string => {
+    const normalized = baseUrl.replace(/\/+$/, '')
+
+    if (mode === 'legacy') {
+      if (normalized.startsWith('https://')) {
+        return `${normalized}/mps/ws/relay`
+      }
+      if (normalized.startsWith('http://')) {
+        return `${normalized}/relay`
+      }
+      return normalized
     }
-    return baseUrl
+
+    if (normalized.startsWith('https://') || normalized.startsWith('http://')) {
+      return `${normalized}/relay`
+    }
+    return normalized
   }
-  const relayServer = getRelayServer(config.mpsServer)
+  const relayServer = getRelayServer(config.mpsServer, apiMode)
 
   const updateConfig = (field: string, value: string) => {
     setConfig((c) => ({ ...c, [field]: value }))
   }
 
   const componentProps = {
-    deviceId: auth.systemId || config.deviceId,
+    deviceId: apiMode === 'redfish' ? auth.deviceId || config.deviceId : config.deviceId,
     mpsServer: relayServer,
     authToken: auth.token
   }
@@ -56,28 +69,71 @@ const App: React.FC = () => {
       </div>
 
       <div className='config-panel'>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '8px',
+            marginBottom: '12px'
+          }}
+        >
+          <span style={{ fontWeight: 600 }}>API Mode:</span>
+          <button
+            type='button'
+            onClick={() => setApiMode('legacy')}
+            disabled={auth.isAuthenticated || auth.isLoading}
+            style={{
+              padding: '6px 10px',
+              borderRadius: '4px',
+              border: '1px solid #ccc',
+              backgroundColor: apiMode === 'legacy' ? '#007bff' : '#fff',
+              color: apiMode === 'legacy' ? '#fff' : '#333',
+              cursor: auth.isAuthenticated || auth.isLoading ? 'not-allowed' : 'pointer',
+              opacity: auth.isAuthenticated || auth.isLoading ? 0.6 : 1
+            }}
+          >
+            Console REST (Legacy)
+          </button>
+          <button
+            type='button'
+            onClick={() => setApiMode('redfish')}
+            disabled={auth.isAuthenticated || auth.isLoading}
+            style={{
+              padding: '6px 10px',
+              borderRadius: '4px',
+              border: '1px solid #ccc',
+              backgroundColor: apiMode === 'redfish' ? '#007bff' : '#fff',
+              color: apiMode === 'redfish' ? '#fff' : '#333',
+              cursor: auth.isAuthenticated || auth.isLoading ? 'not-allowed' : 'pointer',
+              opacity: auth.isAuthenticated || auth.isLoading ? 0.6 : 1
+            }}
+          >
+            Redfish API
+          </button>
+        </div>
+
         <div className='config-grid'>
           <input
-            placeholder='https://<host[:port]>'
+            placeholder='http(s)://<host[:port]>'
             value={config.mpsServer}
             onChange={(e) => updateConfig('mpsServer', e.target.value)}
             disabled={auth.isAuthenticated}
           />
           <input
-            placeholder='System ID (optional, auto-discovers first if empty)'
+            placeholder='Device ID (optional for Redfish auto-discovery)'
             value={config.deviceId}
             onChange={(e) => updateConfig('deviceId', e.target.value)}
             disabled={auth.isAuthenticated}
           />
           <input
-            placeholder='Redfish Username'
+            placeholder='Username'
             value={config.username}
             onChange={(e) => updateConfig('username', e.target.value)}
             disabled={auth.isAuthenticated}
           />
           <input
             type='password'
-            placeholder='Redfish Password'
+            placeholder='Password'
             value={config.password}
             onChange={(e) => updateConfig('password', e.target.value)}
             disabled={auth.isAuthenticated}
@@ -88,15 +144,19 @@ const App: React.FC = () => {
           <button
             className={auth.isAuthenticated ? 'btn-danger' : 'btn-success'}
             onClick={() =>
-              auth.isAuthenticated ? auth.disconnect() : auth.connect(config)
+              auth.isAuthenticated ? auth.disconnect() : auth.connect(config, apiMode)
             }
             disabled={auth.isLoading}
           >
             {auth.isLoading
-              ? 'Connecting...'
+              ? apiMode === 'legacy'
+                ? 'Authenticating...'
+                : 'Connecting...'
               : auth.isAuthenticated
                 ? 'Disconnect'
-                : 'Connect'}
+                : apiMode === 'legacy'
+                  ? 'Authenticate'
+                  : 'Connect'}
           </button>
         </div>
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -31,10 +31,7 @@ const App: React.FC = () => {
 
   const auth = useAuth()
   const getRelayServer = (baseUrl: string): string => {
-    if (baseUrl.startsWith('https://')) {
-      return `${baseUrl}/mps/ws/relay`
-    }
-    if (baseUrl.startsWith('http://')) {
+    if (baseUrl.startsWith('https://') || baseUrl.startsWith('http://')) {
       return `${baseUrl}/relay`
     }
     return baseUrl
@@ -46,7 +43,7 @@ const App: React.FC = () => {
   }
 
   const componentProps = {
-    deviceId: config.deviceId,
+    deviceId: auth.systemId || config.deviceId,
     mpsServer: relayServer,
     authToken: auth.token
   }
@@ -61,26 +58,26 @@ const App: React.FC = () => {
       <div className='config-panel'>
         <div className='config-grid'>
           <input
-            placeholder='/mps/login or /api/v1/authorize'
+            placeholder='https://<host[:port]>'
             value={config.mpsServer}
             onChange={(e) => updateConfig('mpsServer', e.target.value)}
             disabled={auth.isAuthenticated}
           />
           <input
-            placeholder='Device GUID'
+            placeholder='System ID (optional, auto-discovers first if empty)'
             value={config.deviceId}
             onChange={(e) => updateConfig('deviceId', e.target.value)}
             disabled={auth.isAuthenticated}
           />
           <input
-            placeholder='MPS Username'
+            placeholder='Redfish Username'
             value={config.username}
             onChange={(e) => updateConfig('username', e.target.value)}
             disabled={auth.isAuthenticated}
           />
           <input
             type='password'
-            placeholder='MPS Password'
+            placeholder='Redfish Password'
             value={config.password}
             onChange={(e) => updateConfig('password', e.target.value)}
             disabled={auth.isAuthenticated}
@@ -96,10 +93,10 @@ const App: React.FC = () => {
             disabled={auth.isLoading}
           >
             {auth.isLoading
-              ? 'Authenticating...'
+              ? 'Connecting...'
               : auth.isAuthenticated
                 ? 'Disconnect'
-                : 'Authenticate'}
+                : 'Connect'}
           </button>
         </div>
 

--- a/example/src/useAuth.ts
+++ b/example/src/useAuth.ts
@@ -5,9 +5,11 @@
 
 import { useState } from 'react'
 
+export type ApiMode = 'legacy' | 'redfish'
+
 interface AuthState {
   token: string
-  systemId: string
+  deviceId: string
   isAuthenticated: boolean
   isLoading: boolean
   error: string
@@ -69,16 +71,22 @@ const parseSystemIdFromPath = (systemPath: string): string => {
 export const useAuth = () => {
   const [state, setState] = useState<AuthState>({
     token: '',
-    systemId: '',
+    deviceId: '',
     isAuthenticated: false,
     isLoading: false,
     error: ''
   })
 
-  const connect = async (config: AuthConfig) => {
+  const connect = async (config: AuthConfig, apiMode: ApiMode) => {
     const { mpsServer, deviceId, username, password } = config
 
-    if (!username || !password || !mpsServer) {
+    const missingRequiredFields =
+      !username ||
+      !password ||
+      !mpsServer ||
+      (apiMode === 'legacy' && !deviceId)
+
+    if (missingRequiredFields) {
       setState((s) => ({ ...s, error: 'Please fill in all required fields' }))
       return
     }
@@ -90,87 +98,166 @@ export const useAuth = () => {
       if (!/^https?:\/\//.test(baseUrl)) {
         throw new Error('Server URL must start with http:// or https://')
       }
-      const authHeader = getBasicAuthHeader(username, password)
 
-      let systemPath = ''
-      if (deviceId.trim().length > 0) {
-        systemPath = getSystemPathFromInput(deviceId.trim())
+      if (apiMode === 'legacy') {
+        // Support both deployment styles by trying both legacy auth paths.
+        const authPaths = ['/api/v1/authorize', '/mps/login/api/v1/authorize']
+        let authBody: { token?: string; accessToken?: string } | null = null
+        let authPathUsed = ''
+        let authError = 'Authentication failed'
+
+        for (const authPath of authPaths) {
+          const authRes = await fetch(`${baseUrl}${authPath}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ username, password })
+          })
+
+          if (!authRes.ok) {
+            authError = `Authentication failed: ${authRes.status} ${authRes.statusText}`
+            continue
+          }
+
+          const contentType = authRes.headers.get('content-type') ?? ''
+          if (!contentType.includes('application/json')) {
+            authError = `Authentication endpoint returned non-JSON response at ${authPath}`
+            continue
+          }
+
+          authBody = (await authRes.json()) as {
+            token?: string
+            accessToken?: string
+          }
+          authPathUsed = authPath
+          break
+        }
+
+        if (!authBody) {
+          throw new Error(authError)
+        }
+
+        const accessToken = authBody.token ?? authBody.accessToken
+
+        if (!accessToken) {
+          throw new Error('No token received')
+        }
+
+        const redirRes = await fetch(
+          `${baseUrl}${authPathUsed}/redirection/${encodeURIComponent(deviceId.trim())}`,
+          {
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${accessToken}`
+            }
+          }
+        )
+
+        if (!redirRes.ok) {
+          throw new Error(
+            `Redirection failed: ${redirRes.status} ${redirRes.statusText}`
+          )
+        }
+
+        const redirBody = (await redirRes.json()) as {
+          token?: string
+          RedirectionToken?: string
+          Token?: string
+        }
+        const token = redirBody.token ?? redirBody.RedirectionToken ?? redirBody.Token
+        if (!token) {
+          throw new Error('No redirection token received')
+        }
+
+        setState({
+          token,
+          deviceId: deviceId.trim(),
+          isAuthenticated: true,
+          isLoading: false,
+          error: ''
+        })
       } else {
-        const systemsRes = await fetch(`${baseUrl}/redfish/v1/Systems`, {
+        const authHeader = getBasicAuthHeader(username, password)
+
+        let systemPath = ''
+        if (deviceId.trim().length > 0) {
+          systemPath = getSystemPathFromInput(deviceId.trim())
+        } else {
+          const systemsRes = await fetch(`${baseUrl}/redfish/v1/Systems`, {
+            headers: {
+              Accept: 'application/json',
+              Authorization: authHeader
+            }
+          })
+          if (!systemsRes.ok) {
+            throw new Error(
+              `Failed to list systems: ${systemsRes.status} ${systemsRes.statusText}`
+            )
+          }
+
+          const systemsBody = (await systemsRes.json()) as RedfishMembersResponse
+          const firstMember = systemsBody.Members?.[0]?.['@odata.id']
+          if (!firstMember) {
+            throw new Error('No systems found at /redfish/v1/Systems')
+          }
+
+          systemPath = firstMember
+        }
+
+        const systemRes = await fetch(toAbsoluteUrl(baseUrl, systemPath), {
           headers: {
             Accept: 'application/json',
             Authorization: authHeader
           }
         })
-        if (!systemsRes.ok) {
+        if (!systemRes.ok) {
           throw new Error(
-            `Failed to list systems: ${systemsRes.status} ${systemsRes.statusText}`
+            `Failed to read system: ${systemRes.status} ${systemRes.statusText}`
           )
         }
 
-        const systemsBody = (await systemsRes.json()) as RedfishMembersResponse
-        const firstMember = systemsBody.Members?.[0]?.['@odata.id']
-        if (!firstMember) {
-          throw new Error('No systems found at /redfish/v1/Systems')
+        const systemBody = (await systemRes.json()) as RedfishSystem
+
+        const actionTarget =
+          systemBody.Actions?.Oem?.[
+            '#IntelComputerSystem.GenerateRedirectionToken'
+          ]?.target
+        const fallbackActionPath = `${systemPath.replace(/\/+$/, '')}/Actions/Oem/IntelComputerSystem.GenerateRedirectionToken`
+        const actionUrl = toAbsoluteUrl(baseUrl, actionTarget ?? fallbackActionPath)
+
+        const tokenRes = await fetch(actionUrl, {
+          method: 'POST',
+          headers: {
+            Accept: 'application/json',
+            'Content-Type': 'application/json',
+            Authorization: authHeader
+          },
+          body: JSON.stringify({})
+        })
+        if (!tokenRes.ok) {
+          throw new Error(
+            `Token action failed: ${tokenRes.status} ${tokenRes.statusText}`
+          )
         }
 
-        systemPath = firstMember
-      }
-
-      const systemRes = await fetch(toAbsoluteUrl(baseUrl, systemPath), {
-        headers: {
-          Accept: 'application/json',
-          Authorization: authHeader
+        const tokenBody = (await tokenRes.json()) as {
+          token?: string
+          RedirectionToken?: string
+          Token?: string
         }
-      })
-      if (!systemRes.ok) {
-        throw new Error(
-          `Failed to read system: ${systemRes.status} ${systemRes.statusText}`
-        )
+        const token =
+          tokenBody.token ?? tokenBody.RedirectionToken ?? tokenBody.Token
+        if (!token) {
+          throw new Error('No redirection token returned by action')
+        }
+
+        setState({
+          token,
+          deviceId: systemBody.Id ?? parseSystemIdFromPath(systemPath),
+          isAuthenticated: true,
+          isLoading: false,
+          error: ''
+        })
       }
-
-      const systemBody = (await systemRes.json()) as RedfishSystem
-
-      const actionTarget =
-        systemBody.Actions?.Oem?.[
-          '#IntelComputerSystem.GenerateRedirectionToken'
-        ]?.target
-      const fallbackActionPath = `${systemPath.replace(/\/+$/, '')}/Actions/Oem/IntelComputerSystem.GenerateRedirectionToken`
-      const actionUrl = toAbsoluteUrl(baseUrl, actionTarget ?? fallbackActionPath)
-
-      const tokenRes = await fetch(actionUrl, {
-        method: 'POST',
-        headers: {
-          Accept: 'application/json',
-          'Content-Type': 'application/json',
-          Authorization: authHeader
-        },
-        body: JSON.stringify({})
-      })
-      if (!tokenRes.ok) {
-        throw new Error(
-          `Token action failed: ${tokenRes.status} ${tokenRes.statusText}`
-        )
-      }
-
-      const tokenBody = (await tokenRes.json()) as {
-        token?: string
-        RedirectionToken?: string
-        Token?: string
-      }
-      const token =
-        tokenBody.token ?? tokenBody.RedirectionToken ?? tokenBody.Token
-      if (!token) {
-        throw new Error('No redirection token returned by action')
-      }
-
-      setState({
-        token,
-        systemId: systemBody.Id ?? parseSystemIdFromPath(systemPath),
-        isAuthenticated: true,
-        isLoading: false,
-        error: ''
-      })
     } catch (err) {
       setState((s) => ({
         ...s,
@@ -183,7 +270,7 @@ export const useAuth = () => {
   const disconnect = () => {
     setState({
       token: '',
-      systemId: '',
+      deviceId: '',
       isAuthenticated: false,
       isLoading: false,
       error: ''

--- a/example/src/useAuth.ts
+++ b/example/src/useAuth.ts
@@ -7,6 +7,7 @@ import { useState } from 'react'
 
 interface AuthState {
   token: string
+  systemId: string
   isAuthenticated: boolean
   isLoading: boolean
   error: string
@@ -19,9 +20,56 @@ interface AuthConfig {
   password: string
 }
 
+interface RedfishSystem {
+  Id?: string
+  Actions?: {
+    Oem?: {
+      '#IntelComputerSystem.GenerateRedirectionToken'?: {
+        target?: string
+      }
+    }
+  }
+}
+
+interface RedfishMembersResponse {
+  Members?: Array<{
+    '@odata.id'?: string
+  }>
+}
+
+const ensureNoTrailingSlash = (url: string): string => url.replace(/\/+$/, '')
+
+const toAbsoluteUrl = (baseUrl: string, pathOrUrl: string): string => {
+  if (pathOrUrl.startsWith('http://') || pathOrUrl.startsWith('https://')) {
+    return pathOrUrl
+  }
+  if (pathOrUrl.startsWith('/')) {
+    return `${baseUrl}${pathOrUrl}`
+  }
+  return `${baseUrl}/${pathOrUrl}`
+}
+
+const getBasicAuthHeader = (username: string, password: string): string => {
+  return `Basic ${btoa(`${username}:${password}`)}`
+}
+
+const getSystemPathFromInput = (deviceId: string): string => {
+  if (deviceId.startsWith('/redfish/v1/Systems/')) {
+    return deviceId
+  }
+  return `/redfish/v1/Systems/${encodeURIComponent(deviceId)}`
+}
+
+const parseSystemIdFromPath = (systemPath: string): string => {
+  const trimmed = systemPath.replace(/\/+$/, '')
+  const parts = trimmed.split('/')
+  return decodeURIComponent(parts[parts.length - 1] ?? '')
+}
+
 export const useAuth = () => {
   const [state, setState] = useState<AuthState>({
     token: '',
+    systemId: '',
     isAuthenticated: false,
     isLoading: false,
     error: ''
@@ -30,7 +78,7 @@ export const useAuth = () => {
   const connect = async (config: AuthConfig) => {
     const { mpsServer, deviceId, username, password } = config
 
-    if (!username || !password || !deviceId || !mpsServer) {
+    if (!username || !password || !mpsServer) {
       setState((s) => ({ ...s, error: 'Please fill in all required fields' }))
       return
     }
@@ -38,43 +86,91 @@ export const useAuth = () => {
     setState((s) => ({ ...s, isLoading: true, error: '' }))
 
     try {
-      // Determine API path based on protocol
-      // HTTPS: /mps/login/api/v1/authorize
-      // HTTP:  /api/v1/authorize
-      const isHttps = mpsServer.startsWith('https://')
-      const authPath = isHttps ? '/mps/login/api/v1/authorize' : '/api/v1/authorize'
+      const baseUrl = ensureNoTrailingSlash(mpsServer)
+      if (!/^https?:\/\//.test(baseUrl)) {
+        throw new Error('Server URL must start with http:// or https://')
+      }
+      const authHeader = getBasicAuthHeader(username, password)
 
-      // Get access token
-      const authRes = await fetch(`${mpsServer}${authPath}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username, password })
-      })
-
-      if (!authRes.ok)
-        throw new Error(`Authentication failed: ${authRes.statusText}`)
-
-      const { token: accessToken } = await authRes.json()
-      if (!accessToken) throw new Error('No token received')
-
-      // Get redirection token
-      const redirRes = await fetch(
-        `${mpsServer}${authPath}/redirection/${deviceId}`,
-        {
+      let systemPath = ''
+      if (deviceId.trim().length > 0) {
+        systemPath = getSystemPathFromInput(deviceId.trim())
+      } else {
+        const systemsRes = await fetch(`${baseUrl}/redfish/v1/Systems`, {
           headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${accessToken}`
+            Accept: 'application/json',
+            Authorization: authHeader
           }
+        })
+        if (!systemsRes.ok) {
+          throw new Error(
+            `Failed to list systems: ${systemsRes.status} ${systemsRes.statusText}`
+          )
         }
-      )
 
-      if (!redirRes.ok)
-        throw new Error(`Redirection failed: ${redirRes.statusText}`)
+        const systemsBody = (await systemsRes.json()) as RedfishMembersResponse
+        const firstMember = systemsBody.Members?.[0]?.['@odata.id']
+        if (!firstMember) {
+          throw new Error('No systems found at /redfish/v1/Systems')
+        }
 
-      const { token } = await redirRes.json()
-      if (!token) throw new Error('No redirection token received')
+        systemPath = firstMember
+      }
 
-      setState({ token, isAuthenticated: true, isLoading: false, error: '' })
+      const systemRes = await fetch(toAbsoluteUrl(baseUrl, systemPath), {
+        headers: {
+          Accept: 'application/json',
+          Authorization: authHeader
+        }
+      })
+      if (!systemRes.ok) {
+        throw new Error(
+          `Failed to read system: ${systemRes.status} ${systemRes.statusText}`
+        )
+      }
+
+      const systemBody = (await systemRes.json()) as RedfishSystem
+
+      const actionTarget =
+        systemBody.Actions?.Oem?.[
+          '#IntelComputerSystem.GenerateRedirectionToken'
+        ]?.target
+      const fallbackActionPath = `${systemPath.replace(/\/+$/, '')}/Actions/Oem/IntelComputerSystem.GenerateRedirectionToken`
+      const actionUrl = toAbsoluteUrl(baseUrl, actionTarget ?? fallbackActionPath)
+
+      const tokenRes = await fetch(actionUrl, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Authorization: authHeader
+        },
+        body: JSON.stringify({})
+      })
+      if (!tokenRes.ok) {
+        throw new Error(
+          `Token action failed: ${tokenRes.status} ${tokenRes.statusText}`
+        )
+      }
+
+      const tokenBody = (await tokenRes.json()) as {
+        token?: string
+        RedirectionToken?: string
+        Token?: string
+      }
+      const token =
+        tokenBody.token ?? tokenBody.RedirectionToken ?? tokenBody.Token
+      if (!token) {
+        throw new Error('No redirection token returned by action')
+      }
+
+      setState({
+        token,
+        systemId: systemBody.Id ?? parseSystemIdFromPath(systemPath),
+        isAuthenticated: true,
+        isLoading: false,
+        error: ''
+      })
     } catch (err) {
       setState((s) => ({
         ...s,
@@ -87,6 +183,7 @@ export const useAuth = () => {
   const disconnect = () => {
     setState({
       token: '',
+      systemId: '',
       isAuthenticated: false,
       isLoading: false,
       error: ''

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -10,6 +10,14 @@ export default defineConfig({
         __dirname,
         '../src/index.ts'
       ),
+      '@device-management-toolkit/ui-toolkit/core': path.resolve(
+        __dirname,
+        'node_modules/@device-management-toolkit/ui-toolkit/bundles/core.bundle.js'
+      ),
+      '@xterm/xterm': path.resolve(
+        __dirname,
+        'node_modules/@xterm/xterm/lib/xterm.js'
+      ),
       // Dedupe React to prevent multiple instances
       react: path.resolve(__dirname, 'node_modules/react'),
       'react-dom': path.resolve(__dirname, 'node_modules/react-dom'),


### PR DESCRIPTION
## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

Replace /api/v1/authorize + /redirection/{id} legacy flow with:
  1. GET /redfish/v1/Systems (auto-discover system when ID not provided)
  2. GET /redfish/v1/Systems/{id} (read system + extract OEM action URL)
  3. POST .../Actions/Oem/IntelComputerSystem.GenerateRedirectionToken
- Use Basic auth header for all Redfish requests
- Store resolved system ID in hook state for KVM/SOL/IDER components
- Fix relay server base URL to /relay (toolkit core appends /webrelay.ashx)
- Update example UI labels and placeholders for Redfish context


After the changes the toggle button looks like, 
<img width="1270" height="754" alt="image" src="https://github.com/user-attachments/assets/2c59e7df-c3d7-4337-9d36-653886086721" />


