### PR TITLE
docs: update Scorecard badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CodeQL](https://img.shields.io/github/actions/workflow/status/device-management-toolkit/ui-toolkit-react/codeql-analysis.yml?style=for-the-badge&label=CodeQL&logo=github)
 ![Build](https://img.shields.io/github/actions/workflow/status/device-management-toolkit/ui-toolkit-react/ci.yml?style=for-the-badge&logo=github)
 ![Codecov](https://img.shields.io/codecov/c/github/device-management-toolkit/ui-toolkit-react?style=for-the-badge&logo=codecov)
-[![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/device-management-toolkit/ui-toolkit-react?style=for-the-badge&label=OSSF%20Score)](https://api.securityscorecards.dev/projects/github.com/open-amt-cloud-toolkit/ui-toolkir-react)
+[![OSSF-Scorecard Score](https://img.shields.io/ossf-scorecard/github.com/device-management-toolkit/ui-toolkit-react?style=for-the-badge&label=OSSF%20Score)](https://api.securityscorecards.dev/projects/github.com/device-management-toolkit/ui-toolkit-react)
 [![Discord](https://img.shields.io/discord/1063200098680582154?style=for-the-badge&label=Discord&logo=discord&logoColor=white&labelColor=%235865F2&link=https%3A%2F%2Fdiscord.gg%2FDKHeUNEWVH)](https://discord.gg/DKHeUNEWVH)
 
 > Disclaimer: Production viable releases are tagged and listed under 'Releases'. All other check-ins should be considered 'in-development' and should not be used in production


### PR DESCRIPTION
## Summary
- update the OSSF Scorecard badge link to point at the current `device-management-toolkit/ui-toolkit-react` repository
- remove the stale `open-amt-cloud-toolkit/ui-toolkir-react` target from the badge link

## Verification
- `git diff --check`
- `curl -sS -o /dev/null -w '%{http_code} %{url_effective}\n' 'https://api.securityscorecards.dev/projects/github.com/open-amt-cloud-toolkit/ui-toolkir-react'` -> `404 https://api.securityscorecards.dev/projects/github.com/open-amt-cloud-toolkit/ui-toolkir-react`
- `curl -sS -o /dev/null -w '%{http_code} %{url_effective}\n' 'https://api.securityscorecards.dev/projects/github.com/device-management-toolkit/ui-toolkit-react'` -> `200 https://api.securityscorecards.dev/projects/github.com/device-management-toolkit/ui-toolkit-react`