### PR TITLE
ci(gh-actions): resolve zizmor findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,6 @@ jobs:
   # This workflow contains a single job called "build"
   build:
     # The type of runner that the job will run on
-    permissions:
-      contents: write # for Git to git push
     runs-on: ubuntu-latest
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -34,6 +32,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Use Node.js 24.x
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -52,6 +52,8 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,10 +48,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.ROSIE_TOKEN }}
       - name: Publish to @open-amt-cloud-toolkit
         if: steps.semantic.outputs.new_release_published == 'true'
+        env:
+          NEW_RELEASE_VERSION: ${{ steps.semantic.outputs.new_release_version }}
         run: |
-          echo "Publishing @open-amt-cloud-toolkit/ui-toolkit-react@${{ steps.semantic.outputs.new_release_version }}"
+          echo "Publishing @open-amt-cloud-toolkit/ui-toolkit-react@$NEW_RELEASE_VERSION"
 
           sed -i 's/"@device-management-toolkit\/ui-toolkit-react"/"@open-amt-cloud-toolkit\/ui-toolkit-react"/' dist/package.json
-          sed -i 's/"version": "[^"]*"/"version": "${{ steps.semantic.outputs.new_release_version }}"/' dist/package.json
+          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$NEW_RELEASE_VERSION\"/" dist/package.json
           cd dist
           npm publish

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: .github/commitlint.config.cjs

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+# Zizmor configuration. See https://docs.zizmor.sh/configuration/
+rules:
+  # Daily updates with no cooldown are intentional here. A version compromised
+  # at publish time can reach CI before it is yanked, but the blast radius is
+  # small: Dependabot PRs do not receive repository secrets by default and run
+  # with a read-only GITHUB_TOKEN.
+  dependabot-cooldown:
+    ignore:
+      - dependabot.yml


### PR DESCRIPTION
- Set persist-credentials: false on the actions/checkout steps in ci, codeql-analysis, dependency-review and semantic. None of these jobs push with the checkout token, so dropping it is safe.
- Move the semantic-release version output out of the publish run block in release.yml into an env var and quote it in the shell.
- Add .github/zizmor.yml ignoring dependabot-cooldown for dependabot.yml; daily updates with no cooldown are intentional.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
